### PR TITLE
Not equal query build support <>

### DIFF
--- a/dist/queryGenerator.js
+++ b/dist/queryGenerator.js
@@ -149,6 +149,9 @@ return lastIndex !== -1 && lastIndex === position;
     QueryGenerator._getWhereOperator = function(field) {
       var operatorHandler, operators;
       operators = {
+        notEqualOperator: {
+          operator: '<>'
+        },
         greaterOrEqualThanOperator: {
           operator: '>='
         },
@@ -170,6 +173,8 @@ return lastIndex !== -1 && lastIndex === position;
       };
       operatorHandler = (function() {
         switch (false) {
+          case !field.endsWith('<>'):
+            return operators.notEqualOperator;
           case !field.endsWith('>='):
             return operators.greaterOrEqualThanOperator;
           case !field.endsWith('>'):

--- a/lib/queryGenerator.coffee
+++ b/lib/queryGenerator.coffee
@@ -130,6 +130,7 @@ class QueryGenerator
 
   @_getWhereOperator: (field) ->
     operators = {
+      notEqualOperator: { operator: '<>' }
       greaterOrEqualThanOperator: { operator: '>=' }
       greaterThanOperator: { operator: '>' }
       lessOrEqualThanOperator: { operator: '<=' }
@@ -139,6 +140,7 @@ class QueryGenerator
     }
 
     operatorHandler = switch
+      when field.endsWith '<>' then operators.notEqualOperator
       when field.endsWith '>=' then operators.greaterOrEqualThanOperator
       when field.endsWith '>' then operators.greaterThanOperator
       when field.endsWith '<=' then operators.lessOrEqualThanOperator

--- a/test/queryGenerator.spec.coffee
+++ b/test/queryGenerator.spec.coffee
@@ -312,6 +312,15 @@ describe 'Query generator', ->
           relations: []
         }
 
+       it 'single not equal condition, result should be as expected', ->
+        expect(QueryGenerator._toWhere({
+          'employee_id<>': 15
+        }, config)).to.deep.equal {
+          where: 'tasks."employee_id" <> $1'
+          params: [ 15 ]
+          relations: []
+        }
+
       it 'single greater or equal than column of an relation condition, result should be as expected', ->
         expect(QueryGenerator._toWhere({
           'employee_name>=': 15


### PR DESCRIPTION
Because I decided to use `<>` instead of `!=` According to this message on the site at the end it will end up becoming `<>` so it doesn't make sense to be different.

![image](https://user-images.githubusercontent.com/40774281/84659640-19694400-aeee-11ea-8899-04337df627d4.png)
Source: https://www.postgresql.org/docs/9.5/functions-comparison.html

closes #3