### PR TITLE
fix: 🐛 config param to paginate only  main table

### DIFF
--- a/dist/queryGenerator.js
+++ b/dist/queryGenerator.js
@@ -53,12 +53,13 @@ return lastIndex !== -1 && lastIndex === position;
     };
 
     QueryGenerator.toSql = function(args, config) {
-      var columns, joins, pageOptions, relations, sortOptions, whereResult;
+      var columns, fromTable, joins, pageOptions, relations, sortOptions, useMainTablePagination, whereResult;
       args.options = args.options || {};
       whereResult = this._toWhere(args.where, config, args.options);
       relations = _.uniq(whereResult.relations.concat(args.relations || []));
       joins = this._toJoinSql(relations, config);
       columns = this._toColumnSql(relations, config, args.options);
+      useMainTablePagination = config.useMainTablePagination || false;
       pageOptions = this._toOptions({
         limit: args.options.limit,
         offset: args.options.offset
@@ -66,10 +67,11 @@ return lastIndex !== -1 && lastIndex === position;
       sortOptions = this._toOptions({
         sort: args.options.sort
       }, config);
+      fromTable = useMainTablePagination ? "( SELECT " + config.table + ".* FROM " + (config.from || config.table) + " " + pageOptions + " ) AS " + config.table : config.from || config.table;
       return {
         sqlCount: "SELECT COUNT(DISTINCT " + config.table + ".\"id\") FROM " + (config.from || config.table) + " " + joins + " WHERE " + whereResult.where + ";",
-        sqlSelectIds: "SELECT " + config.table + ".\"id\" FROM " + (config.from || config.table) + " " + joins + " WHERE " + whereResult.where + " GROUP BY " + config.table + ".\"id\" " + sortOptions + " " + pageOptions + ";",
-        sqlSelect: "SELECT " + columns + " FROM " + (config.from || config.table) + " " + joins + " WHERE " + whereResult.where + " " + sortOptions + " " + pageOptions + ";",
+        sqlSelectIds: "SELECT " + config.table + ".\"id\" FROM " + fromTable + " " + joins + " WHERE " + whereResult.where + " GROUP BY " + config.table + ".\"id\" " + sortOptions + " " + (!useMainTablePagination ? pageOptions : '') + ";",
+        sqlSelect: "SELECT " + columns + " FROM " + fromTable + " " + joins + " WHERE " + whereResult.where + " " + sortOptions + " " + (!useMainTablePagination ? pageOptions : '') + ";",
         params: whereResult.params,
         relations: relations
       };
@@ -306,7 +308,7 @@ return lastIndex !== -1 && lastIndex === position;
           if (column.format) {
             columnName = column.format.replace('{{column}}', columnName);
           }
-          if (options && options.columns) {
+          if (options && options.columns && options.columns.length) {
             if (column.alias && options.columns.includes(column.alias.replace('this.', ''))) {
               results.push(columns.push(columnName + " \"" + column.alias + "\""));
             } else {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "compile": "coffee --compile lib/ test/ && coffee --output dist --compile lib",
-    "test": "mocha",
+    "test": "npm run compile && mocha",
     "autotest": "./node_modules/.bin/supervisor -q -n exit -x npm test"
   },
   "repository": {


### PR DESCRIPTION
✅ Closes: #12

This PR fix the limit pagination issue with configuration parameter based solution.

Now, using the added ```useMainTablePagination``` config parameter, it is possible to page only the main table.

 - Example:

    If we have this config payload:
    ```javascript
    {
      table: 'tasks',
      useMainTablePagination: true
      ...
    }
    ```

   We should get:
   ```sql
   SELECT
     tasks.id,
     tasks.account_id,
     employees.id,
     employees.name
   FROM (SELECT tasks.* FROM tasks LIMIT 25 OFFSET 0) AS tasks
   JOIN employees ON employees.task_id = tasks.id
   ORDER BY tasks.id DESC
    ```

If the ```useMainTablePagination``` parameter is ```false```, it will consider the global pagination, that is, in the whole search, including the relations.

 - Example:

    ```sql
     SELECT
       tasks.id,
       tasks.account_id,
       employees.id,
       employees.name
     FROM tasks
     JOIN employees ON employees.task_id = tasks.id
     ORDER BY tasks.id DESC
     LIMIT 25 OFFSET 0
      ```

The default ```useMainTablePagination```  value is ```false```.