### PR TITLE
Melhoria <> Adição da cláusula "orWhere" 

### DIFF
--- a/lib/queryGenerator.coffee
+++ b/lib/queryGenerator.coffee
@@ -134,7 +134,13 @@ class QueryGenerator
     else
       columnName = fieldConfig.format.replace('{{column}}', columnName) if fieldConfig.format
       result.params.push fieldConfig.mapper(value)
+      if fieldConfig.orWhere and fieldConfig.orWhere.length
+        return result.where.push "(#{columnName} #{fieldOperator.operator} $#{result.params.length}#{@_addOrWhereClause(fieldConfig.orWhere, fieldOperator.operator, result.params.length)})"
       result.where.push "#{columnName} #{fieldOperator.operator} $#{result.params.length}"
+
+  @_addOrWhereClause = (orWhereArray, operator, paramIndex) ->
+    orWhereArray.map (orWhere) ->
+      " or #{orWhere.table}.#{orWhere.column} #{operator} $#{paramIndex}"
 
   @_isSearchField: (config, value) ->
     if config.search[value] then yes else no
@@ -212,6 +218,9 @@ class QueryGenerator
       if searchConfig.relation and config.relations[searchConfig.relation]
         result.relations.push searchConfig.relation if result
         fieldConfiguration.table = config.relations[searchConfig.relation].table
+
+      if searchConfig.orWhere
+        fieldConfiguration.orWhere = searchConfig.orWhere
 
     fieldConfiguration
 

--- a/lib/querySearchParser.coffee
+++ b/lib/querySearchParser.coffee
@@ -33,6 +33,19 @@ class QuerySearchParser
             property: key
             message: "must match #{config.search[key].pattern}"
           }
+      if config.search and config.search[key] and config.search[key].orWhere
+        if not _.isArray config.search[key].orWhere
+          errors.push {
+            property: key
+            message: "property orWhere must be an array"
+          }
+        else
+          for value in config.search[key].orWhere
+            if not (value.table and value.column)
+              errors.push {
+                property: value
+                message: "invalid orWhere configuration, must have table and column"
+              }
 
     return {
       isValid: _.isEmpty(errors)

--- a/test/queryGenerator.spec.coffee
+++ b/test/queryGenerator.spec.coffee
@@ -34,6 +34,16 @@ config = {
       relation: 'info'
       column: 'json_body'
       format: '({{column}}->\'location\'->>\'code\''
+    },
+    employeeId: {
+      column: 'employee_id'
+      pattern: /^\d+$/
+      orWhere: [
+        {
+          table: 'tasks_employees'
+          column: 'employee_id'
+        }
+      ]
     }
   }
 
@@ -324,6 +334,15 @@ describe 'Query generator', ->
         }, config)).to.deep.equal {
           where: 'tasks."status" = $1'
           params: [3]
+          relations: []
+        }
+
+      it 'single equal condition with orWhere configured, result should be as expected', ->
+        expect(QueryGenerator._toWhere({
+          employeeId: '1'
+        }, config)).to.deep.equal {
+          where: '(tasks.\"employee_id\" = $1 or tasks_employees.employee_id = $1)'
+          params: ['1']
           relations: []
         }
 
@@ -731,6 +750,8 @@ describe 'Query generator', ->
           params: [ 1, 3, 2, 'Luiz Freneda', 15, '2015-05-15', '2017-05-15' ]
           relations: [ 'employee' ]
         }
+
+  describe 'orWhere', ->
 
   describe 'Options', ->
 

--- a/test/querySearchParser.coffee
+++ b/test/querySearchParser.coffee
@@ -4,6 +4,7 @@ QuerySearchParser = require './../lib/querySearchParser'
 describe 'Query Search Parser', ->
 
   config = null
+  invalidConfig = null
   beforeEach ->
     config = {
       table: 'tasks'
@@ -32,6 +33,59 @@ describe 'Query Search Parser', ->
           pattern: /^\d{4}-\d{2}-\d{2}$/
         },
         'description~~*': {
+        },
+        employeeId: {
+          column: 'employee_id'
+          pattern: /^\d+$/
+          orWhere: [
+            {
+              table: 'tasks_employees'
+              column: 'employee_id'
+            }
+          ]
+        }
+      }
+      columns: [
+        { name: 'id', alias: 'this.id' }
+        { name: 'description', alias: 'this.description' }
+        { name: 'created_at', alias: 'this.createdAt' }
+        { name: 'employee_id', alias: 'this.employee.id' }
+      ]
+      relations: {
+        employee: {
+          table: 'employees'
+          sql: 'LEFT JOIN employees ON tasks.employee_id = employees.id'
+          columns: [
+            { name: 'id', alias: 'this.employee.id' }
+            { name: 'name', alias: 'this.employee.name' }
+          ]
+        }
+      }
+    }
+    invalidConfig = {
+      table: 'tasks'
+      search: {
+        employee: {
+          column: 'employee_id'
+          pattern: /^\d+$/
+          orWhere: 'ddasd'
+        },
+        scheduledDate: {
+          column: 'date'
+          pattern: /^\d{4}-\d{2}-\d{2}$/
+          orWhere: [
+            {
+              table: 'tasks'
+            }
+          ]
+        },
+        scheduledTime: {
+          column: 'date'
+          orWhere: [
+            {
+              column: 'tasks'
+            }
+          ]
         }
       }
       columns: [
@@ -144,5 +198,43 @@ describe 'Query Search Parser', ->
 
     it 'given invalid object with no config', ->
       validateResult = QuerySearchParser.validate { scheduledDate: 'Invalid date' }, {}
+      expect(validateResult.isValid).to.equal true
+      expect(validateResult.errors).to.deep.equal []
+
+    it 'given invalid orWhere configuration should return a erro validation [1]', ->
+      validateResult = QuerySearchParser.validate { employee: '1' }, invalidConfig
+      expect(validateResult.isValid).to.equal false
+      expect(validateResult.errors).to.deep.equal [
+        {
+          message: 'property orWhere must be an array'
+          property: 'employee'
+        }
+      ]
+    it 'given invalid orWhere configuration should return a erro validation [2]', ->
+      validateResult = QuerySearchParser.validate { scheduledDate: '1999-01-01' }, invalidConfig
+      expect(validateResult.isValid).to.equal false
+      expect(validateResult.errors).to.deep.equal [
+        {
+          message: 'invalid orWhere configuration, must have table and column'
+          property: {
+            table: 'tasks'
+          }
+        }
+      ]
+
+    it 'given invalid orWhere configuration should return a erro validation [3]', ->
+      validateResult = QuerySearchParser.validate { scheduledTime: '1999-01-01' }, invalidConfig
+      expect(validateResult.isValid).to.equal false
+      expect(validateResult.errors).to.deep.equal [
+        {
+          message: 'invalid orWhere configuration, must have table and column'
+          property: {
+            column: 'tasks'
+          }
+        }
+      ]
+
+    it 'given a valid orWhere configuration should return non error validation', ->
+      validateResult = QuerySearchParser.validate { employeeId: '1' }, config
       expect(validateResult.isValid).to.equal true
       expect(validateResult.errors).to.deep.equal []


### PR DESCRIPTION
Essa contribuição permite que possamos fazer algumas busca com condições a mais baseado na KqConfig de cada item dentro da seção search, normalmente conseguimos contornar essa limitação que havia antes dessa contribuição fazendo duas requisições, mas acredito que nesse caso não é possível pois envolve um endpoint que utiliza dos resultados da consulta para fazer a estimativa baseado de algumas regras de negócio, portanto pra não correr o risco de alterar um função que é usada em na principal tela do Field, achei que fazia sentido essa colaboração, segue um exemplo de como fica a implementação: 
![image](https://github.com/lfreneda/katy-query/assets/122394463/8e7e04e9-973c-4a93-9e26-8d983ce9bf73)
